### PR TITLE
Bump compat version numbers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,13 +4,13 @@ authors = ["John Lapeyre <jlapeyre@users.noreply.github.com>"]
 version = "0.2.0"
 
 [deps]
-SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
+SpecialFunctions = "0.8, 0.9, 0.10"
 julia = "1"
 Roots = "0.8"
-SpecialFunctions = "0.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FunctionZeros"
 uuid = "b21f74c0-b399-568f-9643-d20f4fa2c814"
 authors = ["John Lapeyre <jlapeyre@users.noreply.github.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"

--- a/Project.toml
+++ b/Project.toml
@@ -8,9 +8,9 @@ Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
+Roots = "0.8, 1.0"
 SpecialFunctions = "0.8, 0.9, 0.10"
 julia = "1"
-Roots = "0.8"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
This bumps the compat bound for Roots to include v1.0. It also looks like this package is backwards compatible with older SpecialFunctions versions (I tested as far back as v0.8), so I released those version constraints.