### PR TITLE
Bump SpecialFunctions bound to 1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 Roots = "0.8, 1.0"
-SpecialFunctions = "0.8, 0.9, 0.10"
+SpecialFunctions = "0.8, 0.9, 0.10, 1.0"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
SpecialFunctions was updated to v1.0. This PR bumps the bound to 1.0 so that installing this package does not constrain versions of packages that require recent SpecialFunctions features.